### PR TITLE
[ENG-814357] Improving throughputTest to send maximum requests set co…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ throughput_metrics.csv
 
 # Build Artifacts
 vdisk-client
+vdisk_client
 *.exe
 *.dll
 *.so


### PR DESCRIPTION
…ncurrently.

There was an issue with the concurrency logic where the ticker was overloading theCPU and was not matching semaphore release and re-aquiring logic. Replaced the ticker to normal buffer channel logic for semaphores and concurrency is restored.

Pending issue: 120 requests still seems to overload the PE causes a crash, so have tested with 80 requests (8m and 2m work the same, have tested for 2 minutes).

RESULTS:

============================================================ FINAL THROUGHPUT TEST RESULTS
============================================================ Test Duration: 2m7s
Operation Type: read
Max Concurrent: 80

Request Statistics:
  Total Requests: 1211
  Successful: 1211 (100.00%)
  Failed: 0 (0.00%)

Throughput Metrics:
  Requests/sec: 9.53
  Bytes/sec: 999132168.60
  MB/sec: 952.85
  GB/sec: 0.9305

Data Transfer:
  Total Bytes: 126982553600
  Total MB: 121100.00
  Total GB: 118.2617

Latency Statistics:
  Average: 8.237715769s
  Minimum: 149.618818ms
  Maximum: 17.141421446s

Efficiency Metrics:
  Avg bytes per request: 104857600.00
  Requests per minute: 571.71
  MB per minute: 57170.80

============================================================

=== Connection Distribution Report ===
Pool Size: 2 connections
Connection 0: 606 streams (50.0%)
Connection 1: 605 streams (50.0%)
Total streams: 1211
Average per connection: 605.5
Distribution std dev: 0.25 (lower is more equal)
=======================================

Cleaning up connection pool...
Cleaning up connection pool (2 connections)...
Closed connection 0
Closed connection 1
Connection pool cleanup completed